### PR TITLE
ci: cherry pick action not fail when last commit message includes a new line

### DIFF
--- a/workflow-templates/cherry-pick-rc-to-target.yml
+++ b/workflow-templates/cherry-pick-rc-to-target.yml
@@ -92,7 +92,8 @@ jobs:
                   cd ..
                   git add ${{ env.SUBMODULE_NAME }}
                   git commit -m "Update submodule ${{ env.SUBMODULE_NAME }} to latest from ${{ env.TARGET_BRANCH }}"
-                  echo "lastCommitMessage=$LAST_COMMIT_MESSAGE" >> $GITHUB_ENV
+                  # Base64 encode the commit message to avoid issues with newlines and special characters
+                  echo "lastCommitMessageBase64=$(echo "$LAST_COMMIT_MESSAGE" | base64)" >> $GITHUB_ENV
 
             - name: Get Cherry-pick commit
               id: get-cherry
@@ -101,7 +102,9 @@ jobs:
                   if [[ -n "${{ env.SUBMODULE_NAME }}" ]]; then
                     # If SUBMODULE_NAME is set
                     git reset --soft HEAD~2
-                    git commit -m "${{ env.lastCommitMessage }}"
+                    # Decode the base64-encoded string
+                    LAST_COMMIT_MESSAGE=$(echo "${{ env.lastCommitMessageBase64 }}" | base64 --decode)
+                    git commit -m "$LAST_COMMIT_MESSAGE"
                   fi
                   
                   # Get the SHA of the current commit (either squashed or not based on the condition above)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the cherry pick action will fail if there is special characters in the last commit message in this case it was a new line

### Causes (Optional)

env variables do not allow new line 

### Solutions

convert to and from base 64 when storing the last commit message in env variables

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
