### PR TITLE
feat(ci): add reusable Jira PR linking workflow

### DIFF
--- a/.github/workflows/jira-link-pr-reusable.yml
+++ b/.github/workflows/jira-link-pr-reusable.yml
@@ -29,9 +29,9 @@ on:
         type: string
         default: ''
     secrets:
-      GH_TOKEN:
+      github-token:
         required: true
-      JIRA_TOKEN:
+      jira-token:
         required: true
 
 permissions:
@@ -70,12 +70,12 @@ jobs:
         if: steps.check-skip.outputs.should_skip == 'true'
         run: exit 0
 
-      - uses: mohamadjaara/jira-description-action@feat/option-to-fail-based-on-fix-version
+      - uses: mohamadjaara/jira-description-action@139dfb4e202993bdcac44d185423fe11880d85c8
         name: jira-description-action (with compare-fix-version)
         if: ${{ steps.check-skip.outputs.should_skip != 'true' && inputs.version-name != '' }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          jira-token: ${{ secrets.JIRA_TOKEN }}
+          github-token: ${{ secrets.github-token }}
+          jira-token: ${{ secrets.jira-token }}
           jira-base-url: ${{ inputs.jira-base-url }}
           skip-branches: ${{ inputs.skip-branches }}
           fail-when-jira-issue-not-found: true
@@ -87,8 +87,8 @@ jobs:
         name: jira-description-action (without compare-fix-version)
         if: ${{ steps.check-skip.outputs.should_skip != 'true' && inputs.version-name == '' }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          jira-token: ${{ secrets.JIRA_TOKEN }}
+          github-token: ${{ secrets.github-token }}
+          jira-token: ${{ secrets.jira-token }}
           jira-base-url: ${{ inputs.jira-base-url }}
           skip-branches: ${{ inputs.skip-branches }}
           fail-when-jira-issue-not-found: true

--- a/.github/workflows/jira-link-pr-reusable.yml
+++ b/.github/workflows/jira-link-pr-reusable.yml
@@ -1,0 +1,95 @@
+name: Link and Lint PR with Jira Ticket Number (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      jira-base-url:
+        description: 'Base URL for Jira instance'
+        required: false
+        default: 'https://wearezeta.atlassian.net'
+        type: string
+      version-name:
+        description: 'Version name to compare against fix version'
+        required: false
+        default: ''
+        type: string
+      fix-version-regex:
+        description: 'Regex pattern to extract version from fix version field'
+        required: false
+        default: '(?:^|[\s\-_])(v?\d+\.\d+(?:\.\d+)?(?:[\-\+][\w\.\-]*)?)'
+        type: string
+      skip-branches:
+        description: 'Regex pattern for branches to skip'
+        required: false
+        type: string
+        default: '^(production-release|main|master|release\/v\d+)$'
+      skip-actors:
+        description: 'Comma-separated list of actors (users/bots) to skip (e.g., "dependabot[bot],AndroidBob")'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      JIRA_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  add-jira-description:
+    runs-on: ubuntu-latest
+    # Run only if the PR is not from a Fork / external contributor
+    if: ${{ github.repository_owner == 'wireapp' }}
+    steps:
+
+      - name: Check for skipped actors
+        id: check-skip
+        run: |
+          SKIP_ACTORS="${{ inputs.skip-actors }}"
+          ACTOR="${{ github.actor }}"
+
+          # Check if current actor should be skipped
+          SHOULD_SKIP=false
+          IFS=',' read -ra SKIP_ARRAY <<< "$SKIP_ACTORS"
+          for skip_actor in "${SKIP_ARRAY[@]}"; do
+            # Trim whitespace
+            skip_actor=$(echo "$skip_actor" | xargs)
+            if [ "$ACTOR" == "$skip_actor" ]; then
+              SHOULD_SKIP=true
+              echo "PR created by $ACTOR (in skip list), exiting successfully"
+              break
+            fi
+          done
+
+          echo "should_skip=$SHOULD_SKIP" >> $GITHUB_OUTPUT
+
+      - name: Skip if actor is in skip list
+        if: steps.check-skip.outputs.should_skip == 'true'
+        run: exit 0
+
+      - uses: mohamadjaara/jira-description-action@feat/option-to-fail-based-on-fix-version
+        name: jira-description-action (with compare-fix-version)
+        if: ${{ steps.check-skip.outputs.should_skip != 'true' && inputs.version-name != '' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          jira-token: ${{ secrets.JIRA_TOKEN }}
+          jira-base-url: ${{ inputs.jira-base-url }}
+          skip-branches: ${{ inputs.skip-branches }}
+          fail-when-jira-issue-not-found: true
+          skip-ticket-title: true
+          compare-fix-version: ${{ inputs.version-name }}
+          fix-version-regex: ${{ inputs.fix-version-regex }}
+
+      - uses: mohamadjaara/jira-description-action@feat/option-to-fail-based-on-fix-version
+        name: jira-description-action (without compare-fix-version)
+        if: ${{ steps.check-skip.outputs.should_skip != 'true' && inputs.version-name == '' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          jira-token: ${{ secrets.JIRA_TOKEN }}
+          jira-base-url: ${{ inputs.jira-base-url }}
+          skip-branches: ${{ inputs.skip-branches }}
+          fail-when-jira-issue-not-found: true
+          skip-ticket-title: true

--- a/.github/workflows/jira-link-pr-reusable.yml
+++ b/.github/workflows/jira-link-pr-reusable.yml
@@ -83,7 +83,7 @@ jobs:
           compare-fix-version: ${{ inputs.version-name }}
           fix-version-regex: ${{ inputs.fix-version-regex }}
 
-      - uses: mohamadjaara/jira-description-action@feat/option-to-fail-based-on-fix-version
+      - uses: mohamadjaara/jira-description-action@139dfb4e202993bdcac44d185423fe11880d85c8
         name: jira-description-action (without compare-fix-version)
         if: ${{ steps.check-skip.outputs.should_skip != 'true' && inputs.version-name == '' }}
         with:

--- a/.github/workflows/jira-link-pr-reusable.yml
+++ b/.github/workflows/jira-link-pr-reusable.yml
@@ -29,7 +29,7 @@ on:
         type: string
         default: ''
     secrets:
-      GITHUB_TOKEN:
+      GH_TOKEN:
         required: true
       JIRA_TOKEN:
         required: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/

--- a/README.md
+++ b/README.md
@@ -108,11 +108,37 @@ Otto's github token, shared as organization secret, also needs to be made availa
 
 ## Lint and Link PRs to JIRA
 
-For a complete description see https://github.com/marketplace/actions/jira-description
+Use the reusable workflow in this repo instead of the base action.
 
-### Setup
+### Setup (Reusable Workflow)
 
-To add this action click on `Actions` in the top bar of the target repository, scroll to `Workflows created by Wire Swiss GmbH` and click `Set up this workflow`.
+Create a workflow in your repository that calls the reusable workflow from this repo:
+
+```yml
+name: Link and Lint PR with Jira Ticket Number
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+jobs:
+  link-jira:
+    uses: wireapp/.github/.github/workflows/jira-link-pr-reusable.yml@main
+    with:
+      # Optional: override defaults below
+      # jira-base-url: https://wearezeta.atlassian.net
+      # version-name: ''            # omit or leave empty to skip compare
+      # fix-version-regex: '(?:^|[\s\-_])(v?\d+\.\d+(?:\.\d+)?(?:[\-\+][\w\.\-]*)?)'
+      # skip-branches: '^(production-release|main|master|release\/v\d+)$'
+      # skip-actors: 'dependabot[bot],AndroidBob'
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Map your org/repo secret containing the Jira token
+      JIRA_TOKEN: ${{ secrets.OTTO_THE_BOT_JIRA_TOKEN }}
+```
+
+Notes:
+- `version-name` is optional. If omitted or empty, the workflow will not pass `compare-fix-version` to the underlying action.
 
 ### Example
 

--- a/workflow-templates/jira-lint-and-link.yml
+++ b/workflow-templates/jira-lint-and-link.yml
@@ -1,16 +1,35 @@
 name: Link and Lint PR with Jira Ticket Number
 on:
+  merge_group:
   pull_request:
     types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
-  add-jira-description:
+  get-version:
     runs-on: ubuntu-latest
+    # Run only if the PR is not from a Fork / external contributor
+    if: ${{ github.repository_owner == 'wireapp' }}
+    outputs:
+      version_name: ${{ steps.version.outputs.version_name }}
     steps:
-      - uses: cakeinpanic/jira-description-action@v0.3.2
-        name: jira-description-action
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          jira-token: ${{ secrets.JIRA_TOKEN }}
-          jira-base-url: https://wearezeta.atlassian.net
-          skip-branches: '^(production-release|main|master|release\/v\d+)$' #optional
-          fail-when-jira-issue-not-found: true
+      - name: Get version name from source
+        id: version
+        run: |
+          VERSION=do-stuff-to-get-version
+          echo "version_name=$VERSION" >> $GITHUB_OUTPUT
+
+  add-jira-description:
+    needs: get-version
+    uses: wireapp/.github/.github/workflows/jira-link-pr-reusable.yml@{latest-version-commit-hash}
+    with:
+      skip-branches: '^(production-release|main|master|release\/v\d+)$'
+      skip-actors: 'dependabot[bot],AndroidBob'
+      version-name: ${{ needs.get-version.outputs.version_name }}
+      fix-version-regex: '(?:^|[\s\-_])(v?\d+\.\d+(?:\.\d+)?(?:[\-\+][\w\.\-]*)?)'
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      jira-token: ${{ secrets.JIRA_TOKEN }}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

atm eachh repo is using its own jira lint and linking action. 

### Solutions

created a fork of the action and added 2 features to it
1. skip pr title to not post the Jira ticket info in the PR -> hardcoded to true
2. fail if fix version did not match -> optional to compare the repo version name with the one in jira

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
